### PR TITLE
Implement a prompt generator in Rust

### DIFF
--- a/dots/.bashrc
+++ b/dots/.bashrc
@@ -12,7 +12,7 @@ HISTFILESIZE=-1
 
 # http://bashrcgenerator.com/
 prompt_cmd() {
-    PS1="$(rusty-prompt $?)"
+    PS1="$(rusty-prompt $?)\n> "
 }
 
 export -f prompt_cmd

--- a/dots/.bashrc
+++ b/dots/.bashrc
@@ -12,28 +12,7 @@ HISTFILESIZE=-1
 
 # http://bashrcgenerator.com/
 prompt_cmd() {
-    STATUS=$?
-    PS1=""
-    if [ -n "$(jobs)" ]; then
-        PS1+="j\\[\e[34m\]\j\[\e[0m\] "
-    fi
-    if [ $SHLVL -gt 1 ]; then
-        PS1+="s\[\e[34m\]${SHLVL}\[\e[0m\] "
-    fi
-    if [ $EUID -eq 0 ]; then
-        PS1+="\[\e[31m\]\u\[\e[0m\]"
-    else
-        PS1+="\[\e[32m\]\u\[\e[0m\]"
-    fi
-    PS1+=@
-    PS1+="\[\e[33m\]\H\[\e[0m\]"
-    if [ $STATUS -ne 0 ]; then
-        PS1+=" \[\e[1;31m\]\$?\[\e[0;0m\]"
-    fi
-    PROMPT+=" in"
-    # \w full path
-    PS1+=" \w"
-    PS1+=": "
+    PS1="$(rusty-prompt $?)"
 }
 
 export -f prompt_cmd

--- a/dots/.zshrc
+++ b/dots/.zshrc
@@ -73,29 +73,7 @@ zstyle ':vcs_info:*' unstagedstr '%3F-%f '
 zstyle ':vcs_info:*' formats "%c%u%4F%b%f"
 
 kn_prompt() {
-    PROMPT=""
-    if [ -n "$(jobs)" ]; then
-        PS1+="j%6F%j%0f "
-    fi
-    if [ $SHLVL -gt 1 ]; then
-        PROMPT+="s%6F${SHLVL}%0f "
-    fi
-    if [ $EUID -eq 0 ]; then
-        PROMPT+="%1F%n%0f"
-    else
-        PROMPT+="%2F%n%0f"
-    fi
-    PROMPT+=@
-    PROMPT+='%3F%M%0f'
-    if [ $1 -gt 0 ]; then
-        PROMPT+=" %B%1F${1}%0f%b"
-    fi
-    # \w full path
-    PROMPT+=" %3~"
-    [[ -n $vcs_info_msg_0_ ]] && PROMPT+=" ($vcs_info_msg_0_)"
-    [[ -n $VIRTUAL_ENV ]] && PROMPT+=" ($(basename $VIRTUAL_ENV))"
-    PROMPT+=" [$(shell-timer)]"
-    PROMPT+=": "
+    PROMPT="$(rusty-prompt)[$(shell-timer)]: "
 }
 
 export KN_CMD_START_TIME_NS=$(date +%s%N)

--- a/dots/.zshrc
+++ b/dots/.zshrc
@@ -73,7 +73,7 @@ zstyle ':vcs_info:*' unstagedstr '%3F-%f '
 zstyle ':vcs_info:*' formats "%c%u%4F%b%f"
 
 kn_prompt() {
-    PROMPT="$(rusty-prompt)[$(shell-timer)]: "
+    PROMPT="$(rusty-prompt $?)[$(shell-timer)]: "
 }
 
 export KN_CMD_START_TIME_NS=$(date +%s%N)

--- a/dots/.zshrc
+++ b/dots/.zshrc
@@ -61,29 +61,17 @@ bindkey '\[[1;3D'          backward-word
 [[ -d ~/.zsh/functions ]] && fpath=(~/.zsh/functions $fpath)
 
 ### load modules
-autoload -U compinit promptinit colors zcalc vcs_info &&\
+autoload -U compinit promptinit colors zcalc &&\
     compinit &&\
     promptinit &&\
-    colors &&\
-    vcs_info
-
-zstyle ':vcs_info:*' enable git
-zstyle ':vcs_info:*' stagedstr '%2F+%f'
-zstyle ':vcs_info:*' unstagedstr '%3F-%f '
-zstyle ':vcs_info:*' formats "%c%u%4F%b%f"
-
-kn_prompt() {
-    PROMPT="$(rusty-prompt $?)[$(shell-timer)]: "
-}
+    colors
 
 export KN_CMD_START_TIME_NS=$(date +%s%N)
 export KN_CMD_END_TIME_NS=$KN_CMD_START_TIME_NS
 
 precmd() {
     KN_CMD_END_TIME_NS=$(date +%s%N)
-    local STATUS=$?
-    vcs_info
-    kn_prompt $STATUS
+    PROMPT="$(rusty-prompt $?)[$(shell-timer)]: "
 }
 
 preexec() {

--- a/dots/.zshrc
+++ b/dots/.zshrc
@@ -71,7 +71,7 @@ export KN_CMD_END_TIME_NS=$KN_CMD_START_TIME_NS
 
 precmd() {
     KN_CMD_END_TIME_NS=$(date +%s%N)
-    PROMPT="$(rusty-prompt $?)[$(shell-timer)]: "
+    PROMPT="$(rusty-prompt $?)[$(shell-timer)]${prompt_newline}> "
 }
 
 preexec() {

--- a/tools/rusty-prompt/.gitignore
+++ b/tools/rusty-prompt/.gitignore
@@ -1,0 +1,3 @@
+/target/
+/**/*.rs.bk
+/rusty-prompt

--- a/tools/rusty-prompt/Cargo.lock
+++ b/tools/rusty-prompt/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/tools/rusty-prompt/Cargo.lock
+++ b/tools/rusty-prompt/Cargo.lock
@@ -1,0 +1,259 @@
+[[package]]
+name = "bitflags"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cmake"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "colored"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "git2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hostname"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssh2-sys 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rusty-prompt"
+version = "0.1.0"
+dependencies = [
+ "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winutil"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
+"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
+"checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
+"checksum colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0aa3473e85a3161b59845d6096b289bb577874cafeaf75ea1b1beaa6572c7fc"
+"checksum curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71c63a540a9ee4e15e56c3ed9b11a2f121239b9f6d7b7fe30f616e048148df9a"
+"checksum git2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f41c0035c37ec11ed3f1e1946a76070b0c740393687e9a9c7612f6a709036b3"
+"checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
+"checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum libgit2-sys 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9cc8a747e1d0254ef5eb71330fcb8fb25b8b8f8dc1981379b7bb06d6f006672e"
+"checksum libssh2-sys 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5afcb36f9a2012ab8d3a9ba5186ee2d1c4587acf199cb47879a73c5fe1b731a4"
+"checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
+"checksum log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6fddaa003a65722a7fb9e26b0ce95921fe4ba590542ced664d8ce2fa26f9f3ac"
+"checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
+"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)" = "d8abc04833dcedef24221a91852931df2f63e3369ae003134e70aff3645775cc"
+"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
+"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+"checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
+"checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
+"checksum vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cbe533e138811704c0e3cbde65a818b35d3240409b4346256c5ede403e082474"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"

--- a/tools/rusty-prompt/Cargo.toml
+++ b/tools/rusty-prompt/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rusty-prompt"
+version = "0.1.0"
+authors = ["Andreas Linz <klingt.net@gmail.com>"]
+
+[dependencies]
+colored = "1.6"
+hostname = "0.1.5"
+git2 = "0.7"

--- a/tools/rusty-prompt/Cargo.toml
+++ b/tools/rusty-prompt/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Andreas Linz <klingt.net@gmail.com>"]
 colored = "1.6"
 hostname = "0.1.5"
 git2 = "0.7"
+libc = "0.2"

--- a/tools/rusty-prompt/Makefile
+++ b/tools/rusty-prompt/Makefile
@@ -1,0 +1,18 @@
+RUST_SRC=$(wildcard **/*.rs)
+
+all: rusty-prompt
+
+install: rusty-prompt
+ifeq ($$EUID, 0)
+	@install --mode=0755 --verbose rusty-prompt /usr/local/bin
+else
+	@install --mode=0755 --verbose rusty-prompt $$HOME/.local/bin
+endif
+
+rusty-prompt: target/release/rusty-prompt
+	@cp $< $@
+
+target/release/rusty-prompt: $(RUST_SRC)
+	cargo build --release
+# remove debug information	
+	strip $@

--- a/tools/rusty-prompt/src/main.rs
+++ b/tools/rusty-prompt/src/main.rs
@@ -99,10 +99,17 @@ fn user_name() -> ColoredString {
 fn main() {
     let mut prompt: Vec<String> = Vec::new();
 
+    let args = env::args().collect::<Vec<_>>();
+    if let Some(return_code) = args.get(1).and_then(|s| s.parse::<i8>().ok()) {
+        match return_code {
+            0 => (),
+            _ => prompt.push(format!("{}", return_code.to_string().red())),
+        }
+    }
+
     if let Some(lvl) = shell_level() {
         prompt.push(format!("s{}", lvl.blue()));
     };
-
     prompt.push(format!(
         "{}@{}",
         user_name(),

--- a/tools/rusty-prompt/src/main.rs
+++ b/tools/rusty-prompt/src/main.rs
@@ -7,7 +7,7 @@ use colored::*;
 use git2::{DescribeOptions, Repository, RepositoryState};
 use hostname::get_hostname;
 use std::env;
-use std::ffi::CString;
+use std::ffi::CStr;
 
 fn home_path() -> Option<String> {
     if let Some(home_path) = env::home_dir() {
@@ -88,9 +88,7 @@ fn user_name() -> ColoredString {
 
     let username = unsafe {
         let passwd = libc::getpwuid(uid);
-        CString::from_raw((*passwd).pw_name)
-            .into_string()
-            .unwrap_or("unknown".to_owned())
+        CStr::from_ptr((*passwd).pw_name).to_string_lossy()
     };
 
     match uid {

--- a/tools/rusty-prompt/src/main.rs
+++ b/tools/rusty-prompt/src/main.rs
@@ -11,7 +11,7 @@ use std::ffi::CStr;
 
 fn home_path() -> Option<String> {
     if let Some(home_path) = env::home_dir() {
-        Some(home_path.to_string_lossy().into_owned())
+        Some(home_path.to_string_lossy().into())
     } else {
         None
     }
@@ -19,7 +19,7 @@ fn home_path() -> Option<String> {
 
 fn cwd() -> Option<String> {
     if let Ok(cwd_path) = env::current_dir() {
-        Some(cwd_path.to_string_lossy().into_owned())
+        Some(cwd_path.to_string_lossy().into())
     } else {
         None
     }
@@ -29,7 +29,7 @@ fn tilde_home(path: String) -> String {
     if let Some(home) = home_path() {
         return path.replace(&home, "~");
     }
-    path.into()
+    path
 }
 
 fn shell_level() -> Option<String> {
@@ -102,10 +102,11 @@ fn main() {
     if let Some(lvl) = shell_level() {
         prompt.push(format!("s{}", lvl.blue()));
     };
+
     prompt.push(format!(
         "{}@{}",
         user_name(),
-        get_hostname().unwrap_or("unknown-host".to_owned()).yellow()
+        get_hostname().unwrap_or("unknown-host".into()).yellow()
     ));
     prompt.push(tilde_home(cwd().unwrap_or_default()));
     if let Some(git_ref) = git_prompt() {

--- a/tools/rusty-prompt/src/main.rs
+++ b/tools/rusty-prompt/src/main.rs
@@ -1,0 +1,69 @@
+extern crate colored;
+extern crate git2;
+extern crate hostname;
+
+use colored::*;
+use git2::Repository;
+use hostname::get_hostname;
+use std::env;
+use std::process::Command;
+
+fn home_path() -> String {
+    env::home_dir()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn cwd() -> String {
+    env::current_dir()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn tilde_home<S: Into<String>>(path: S) -> String {
+    path.into().replace(&home_path(), "~")
+}
+
+fn user_name() -> String {
+    env::var("USER")
+        .or(env::var("USERNAME"))
+        .unwrap_or_default()
+}
+
+fn host_name() -> String {
+    get_hostname().unwrap_or_default()
+}
+
+fn shell_level() -> String {
+    env::var("SHLVL").unwrap_or_default()
+}
+
+fn git_branch() -> String {
+    let mut cwd = env::current_dir().unwrap();
+    while let Err(_) = Repository::open(&cwd) {
+        if !cwd.pop() {
+            return "".to_owned();
+        }
+    }
+    let repo = Repository::open(cwd).unwrap();
+    let head = repo.head().unwrap();
+    head.shorthand().unwrap_or_default().to_string()
+}
+
+fn virtual_env() -> String {
+    env::var("VIRTUAL_ENV").unwrap_or_default()
+}
+
+fn main() {
+    println!(
+        "s{} {}@{} {} ({}) in {}",
+        shell_level().cyan(),
+        user_name().green(),
+        host_name().yellow(),
+        tilde_home(cwd()),
+        git_branch().blue(),
+        virtual_env().blue(),
+    );
+}

--- a/tools/rusty-prompt/src/main.rs
+++ b/tools/rusty-prompt/src/main.rs
@@ -18,7 +18,7 @@ fn home_path() -> Option<String> {
 }
 
 fn cwd() -> Option<String> {
-    if let Some(cwd_path) = env::current_dir().ok() {
+    if let Ok(cwd_path) = env::current_dir() {
         Some(cwd_path.to_string_lossy().into_owned())
     } else {
         None
@@ -51,9 +51,8 @@ fn git_prompt() -> Option<String> {
             repo_prompt.push(shorthand.to_owned());
         }
     }
-    if let Some(description) = repo.describe(DescribeOptions::new().describe_tags())
+    if let Ok(description) = repo.describe(DescribeOptions::new().describe_tags())
         .and_then(|desc| desc.format(None))
-        .ok()
     {
         repo_prompt.push(format!("@{}", description));
     }

--- a/tools/rusty-prompt/src/main.rs
+++ b/tools/rusty-prompt/src/main.rs
@@ -115,5 +115,5 @@ fn main() {
     if let Some(venv_path) = virtual_env() {
         prompt.push(format!("({})", tilde_home(venv_path).blue()));
     }
-    println!("{}", prompt.join(" "));
+    println!("{}: ", prompt.join(" "));
 }


### PR DESCRIPTION
This small util basically generates the colored prompt I normally define
in `.zshrc` but with the advantage that it is nicer to read and also
much easier to extend. It does everything, including showing the current
git branch name, subshell level and Python virtual environment except
that I couldn't figure out how to get the number of active shell jobs.
Calling the `jobs` builtin is not possible through
`std::process::Command`.
This is more like a WIP at the moment because the commands should return
`Option<S> where S: Into<String>` so the prompt line gets generated dynamically,
i.e. empty parts are not printed like the parentheses around the
git-branch name in a non-git directory.
Also, having some unit tests would be nice :)

PS: The `colored` crate works super nice :ok_hand: